### PR TITLE
Reduces the scopes of the manifest.json file and does a dark mode check on initialization

### DIFF
--- a/src/contextmonitor.js
+++ b/src/contextmonitor.js
@@ -1,6 +1,8 @@
-chrome.runtime.sendMessage({
-  iconContext: {
-    onSite: window.location.href.toLowerCase().includes('thingiverse'),
-    darkMode: window.matchMedia('(prefers-color-scheme: dark)').matches,
-  },
-});
+// Injected into Thingiverse and forwards a message when loading/unloading.
+window.onload = () => {
+  chrome.runtime.sendMessage({onSite: true});
+}
+
+window.onbeforeunload = () => {
+  chrome.runtime.sendMessage({onSite: false});
+}

--- a/src/dark_mode_checker.html
+++ b/src/dark_mode_checker.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="dark_mode_checker.js"></script>
+  </head>
+  <body>
+      <h1>Checking for dark mode...</h1>
+      <p>This page should automatically close.</p>
+  </body>
+</html>

--- a/src/dark_mode_checker.js
+++ b/src/dark_mode_checker.js
@@ -1,0 +1,12 @@
+if (window) {
+    const darkModeEnabled = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    chrome.runtime.sendMessage({darkMode: darkModeEnabled}, () => {
+        // Close the window after sending the message.
+        window.close();
+    });
+} else {
+    // window object didn't exist yet. Default to false and close the window.
+    chrome.runtime.sendMessage({darkMode: false}, () => {
+        window.close();
+    });
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "Thingiverse STL Downloader",
     "description": "Download STLs from Thingiverse -- without the ads.",
-    "version": "1.0",
+    "version": "1.1",
     "manifest_version": 3,
     "permissions": [
         "storage",
@@ -11,7 +11,7 @@
     "content_scripts": [
         {
             "matches": [
-                "https://*/*"
+                "https://*.thingiverse.com/*"
             ],
             "js": [
                 "contextmonitor.js"


### PR DESCRIPTION
Here's a possible solution to reducing the scope of the manifest.json file for the Thingiverse Downloader. My approach was to develop a helper HTML and JS file  to check for the dark mode theme being enabled/disabled. It then forwards that as a runtime message to the background service worker and that will then adjust the constant/icon.

Let me  know what you think about this approach, but hoping it helps (used to TypeScript mostly these days, so was trying to solve this without introducing more packages/dependencies).